### PR TITLE
Handle EXIF orientation in image workers

### DIFF
--- a/docs/local_dev.md
+++ b/docs/local_dev.md
@@ -1,0 +1,13 @@
+# Local Dev / Preview
+
+## Option A — VS Code Live Server
+1. Install the "Live Server" extension.
+2. Right-click `web/index.html` → "Open with Live Server".
+3. Open on your phone via the LAN URL (same Wi-Fi).
+
+## Option B — Python built-in
+```bash
+cd web
+python -m http.server 8080
+# then open http://localhost:8080
+```

--- a/web/worker/dispatcher.js
+++ b/web/worker/dispatcher.js
@@ -1,7 +1,7 @@
-// Dispatches work across multiple workers and builds the final ZIP in main thread
 import { makeZip } from "./zipper-worker.js";
 
-const WORKERS = Math.min(4, navigator.hardwareConcurrency || 2);
+const MAX_WORKERS = (navigator.hardwareConcurrency && navigator.hardwareConcurrency >= 8) ? 6 : 4;
+const WORKERS = Math.max(2, Math.min(MAX_WORKERS, navigator.hardwareConcurrency || 2));
 
 export async function runBatch(files, opts, {signal, onProgress}) {
   const queue = files.slice();

--- a/web/worker/exif.js
+++ b/web/worker/exif.js
@@ -1,0 +1,49 @@
+// Minimal EXIF parser for Orientation from JPEG buffers.
+// Returns 1..8 per EXIF, or 1 if not found/unsupported.
+export function getExifOrientation(arrayBuf) {
+  const view = new DataView(arrayBuf);
+  // JPEG magic
+  if (view.getUint16(0) !== 0xFFD8) return 1;
+  let offset = 2;
+  const length = view.byteLength;
+  while (offset < length) {
+    const marker = view.getUint16(offset);
+    offset += 2;
+    // APP1 (EXIF)
+    if (marker === 0xFFE1) {
+      const size = view.getUint16(offset); // includes size field
+      offset += 2;
+      // Check "Exif\0\0"
+      if (
+        view.getUint32(offset) === 0x45786966 && // "Exif"
+        view.getUint16(offset + 4) === 0x0000
+      ) {
+        const tiff = offset + 6;
+        const little = view.getUint16(tiff) === 0x4949; // 'II'
+        const get16 = (pos) => view.getUint16(pos, little);
+        const get32 = (pos) => view.getUint32(pos, little);
+        const ifd0 = tiff + get32(tiff + 4);
+        const entries = get16(ifd0);
+        for (let i = 0; i < entries; i++) {
+          const entry = ifd0 + 2 + i * 12;
+          const tag = get16(entry);
+          if (tag === 0x0112) { // Orientation
+            const type = get16(entry + 2);
+            const count = get32(entry + 4);
+            if (type === 3 && count === 1) {
+              const val = get16(entry + 8);
+              return val >= 1 && val <= 8 ? val : 1;
+            }
+          }
+        }
+      }
+      offset += size - 2;
+    } else if (marker === 0xFFDA) {
+      // Start of Scan: no more metadata
+      break;
+    } else {
+      offset += view.getUint16(offset);
+    }
+  }
+  return 1;
+}

--- a/web/worker/img-worker.js
+++ b/web/worker/img-worker.js
@@ -1,12 +1,26 @@
+import { getExifOrientation } from "./exif.js";
+
 self.onmessage = async (e) => {
   const { arrayBuf, name, opts } = e.data;
   try {
     const blob = new Blob([arrayBuf]);
     const bitmap = await createImageBitmap(blob);
-    const { canvas, w, h } = await resizeBitmap(bitmap, opts);
+    // Apply EXIF orientation from original ArrayBuffer before any drawing
+    const orient = getExifOrientation(arrayBuf);
+    const oriented = await orientBitmap(bitmap, orient);
+
+    const { canvas, w, h } = await resizeBitmap(oriented, opts);
+
     const outType = opts.format === "png" ? "image/png" : "image/jpeg";
     const quality = opts.format === "png" ? undefined : Math.max(0.1, Math.min(1, (opts.quality || 85) / 100));
-    const outBlob = await canvas.convertToBlob ? await canvas.convertToBlob({ type: outType, quality }) : await new Promise(r=>canvas.toBlob(r, outType, quality));
+
+    // Optional tiny sharpen to avoid mushy downsamples
+    try { tinySharpen(canvas, 0.15); } catch {}
+
+    const outBlob = await (canvas.convertToBlob
+      ? canvas.convertToBlob({ type: outType, quality })
+      : new Promise(r => canvas.toBlob(r, outType, quality)));
+
     const thumbName = makeName(name, w, h, opts.square ? "crop" : "fit", outType);
     const buf = await outBlob.arrayBuffer();
     self.postMessage({ ok:true, name, thumbName, width:w, height:h, data:new Uint8Array(buf) }, [buf]);
@@ -21,13 +35,34 @@ function makeName(original, w, h, mode, mime) {
   return `${base}__w${w}_h${h}__${mode}.${ext}`;
 }
 
+async function orientBitmap(bitmap, orientation) {
+  if (orientation === 1) return bitmap;
+  let w = bitmap.width, h = bitmap.height;
+  const swap = [5,6,7,8].includes(orientation);
+  const cw = swap ? h : w;
+  const ch = swap ? w : h;
+
+  const off = new OffscreenCanvas(cw, ch);
+  const ctx = off.getContext("2d");
+  ctx.save();
+  switch (orientation) {
+    case 2: ctx.translate(cw, 0); ctx.scale(-1, 1); break;              // mirror horizontal
+    case 3: ctx.translate(cw, ch); ctx.rotate(Math.PI); break;          // rotate 180
+    case 4: ctx.translate(0, ch); ctx.scale(1, -1); break;              // mirror vertical
+    case 5: ctx.rotate(0.5*Math.PI); ctx.scale(1, -1); ctx.translate(0, -h); break; // mirror horizontal & rotate 90 CW
+    case 6: ctx.rotate(0.5*Math.PI); ctx.translate(0, -h); break;       // rotate 90 CW
+    case 7: ctx.rotate(0.5*Math.PI); ctx.translate(w, -h); ctx.scale(-1,1); break; // mirror horizontal & rotate 90 CCW
+    case 8: ctx.rotate(-0.5*Math.PI); ctx.translate(-w, 0); break;      // rotate 90 CCW
+  }
+  ctx.drawImage(bitmap, 0, 0);
+  ctx.restore();
+  return off;
+}
+
 async function resizeBitmap(bitmap, opts) {
   const long = opts.size || 512;
-  let targetW, targetH;
-
   if (opts.square) {
     const s = Math.min(bitmap.width, bitmap.height);
-    targetW = targetH = long;
     const sx = (bitmap.width - s)/2;
     const sy = (bitmap.height - s)/2;
     const off = new OffscreenCanvas(long, long);
@@ -37,8 +72,8 @@ async function resizeBitmap(bitmap, opts) {
     return { canvas: off, w: long, h: long };
   } else {
     const scale = bitmap.width >= bitmap.height ? long / bitmap.width : long / bitmap.height;
-    targetW = Math.round(bitmap.width * scale);
-    targetH = Math.round(bitmap.height * scale);
+    const targetW = Math.max(1, Math.round(bitmap.width * scale));
+    const targetH = Math.max(1, Math.round(bitmap.height * scale));
     const off = new OffscreenCanvas(targetW, targetH);
     const ctx = off.getContext("2d");
     ctx.drawImage(bitmap, 0, 0, targetW, targetH);
@@ -50,13 +85,53 @@ async function resizeBitmap(bitmap, opts) {
 function placeWatermark(ctx, w, h, text) {
   ctx.save();
   ctx.globalAlpha = 0.35;
-  ctx.font = `${Math.max(12, Math.round(w*0.05))}px system-ui`;
+  ctx.font = `${Math.max(12, Math.round(w*0.05))}px system-ui, -apple-system, Segoe UI, Roboto, sans-serif`;
   ctx.textBaseline = "bottom";
   const pad = Math.max(8, Math.round(w*0.02));
-  const metrics = ctx.measureText(text);
-  const x = w - pad;
-  const y = h - pad;
   ctx.textAlign = "right";
-  ctx.fillText(text, x, y);
+  ctx.fillText(text, w - pad, h - pad);
   ctx.restore();
+}
+
+// Tiny sharpen: unsharp-like pass using a 3x3 kernel, scaled by amount (0..1)
+function tinySharpen(canvas, amount = 0.15) {
+  const ctx = canvas.getContext("2d");
+  const { width:w, height:h } = canvas;
+  const img = ctx.getImageData(0,0,w,h);
+  const src = img.data;
+  const out = new Uint8ClampedArray(src.length);
+
+  const k = [
+    0,      -1*amount, 0,
+    -1*amount, 1+4*amount, -1*amount,
+    0,      -1*amount, 0
+  ];
+
+  const idx = (x,y) => ((y*w)+x)*4;
+  for (let y=1; y<h-1; y++) {
+    for (let x=1; x<w-1; x++) {
+      for (let c=0; c<3; c++) {
+        let v=0, i=0;
+        for (let ky=-1; ky<=1; ky++) {
+          for (let kx=-1; kx<=1; kx++, i++) {
+            v += src[idx(x+kx,y+ky)+c] * k[i];
+          }
+        }
+        out[idx(x,y)+c] = Math.max(0, Math.min(255, v));
+      }
+      out[idx(x,y)+3] = src[idx(x,y)+3];
+    }
+  }
+  // Copy borders without filtering
+  // Top/bottom
+  out.set(src.slice(0, w*4));
+  out.set(src.slice((h-1)*w*4), (h-1)*w*4);
+  // Left/right columns
+  for (let y=1; y<h-1; y++) {
+    out.set(src.slice(idx(0,y), idx(0,y)+4), idx(0,y));
+    out.set(src.slice(idx(w-1,y), idx(w-1,y)+4), idx(w-1,y));
+  }
+
+  img.data.set(out);
+  ctx.putImageData(img,0,0);
 }


### PR DESCRIPTION
## Summary
- add a minimal EXIF orientation parser for JPEG buffers
- update the image worker to respect EXIF orientation, optionally sharpen outputs, and keep naming consistent
- scale the worker pool based on hardware concurrency and document local web preview setup

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d708f023508331b7c2441a04177eac