### PR TITLE
Add GitHub Pages workflow and changelog entry

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,0 +1,21 @@
+name: Deploy PWA to GitHub Pages
+on:
+push:
+branches: [ main ]
+permissions:
+contents: read
+pages: write
+id-token: write
+jobs:
+deploy:
+runs-on: ubuntu-latest
+steps:
+- uses: actions/checkout@v4
+- name: Setup Pages
+uses: actions/configure-pages@v5
+- name: Upload artifact
+uses: actions/upload-pages-artifact@v3
+with:
+path: web
+- name: Deploy to GitHub Pages
+uses: actions/deploy-pages@v4

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,3 +3,13 @@
 ## [0.1.0] - 2025-09-27
 - Initial PWA skeleton created (mobile-first, offline-ready).
 - Brand tokens wired; index + workers + service worker + manifest added.
+
+[0.1.1] - 2025-09-27
+
+Added EXIF orientation handling for JPEGs.
+
+Added light sharpen pass to improve downscaled clarity.
+
+Wired service worker registration in index.
+
+Added local dev guide and GitHub Pages workflow.


### PR DESCRIPTION
## Summary
- add a GitHub Pages deployment workflow targeting the web output
- document the new automation and related features in the changelog

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d709ef49e083319af92ad09e0a4690