### PR TITLE
Release 0.1.3 UI improvements and worker robustness

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,3 +18,9 @@ Added local dev guide and GitHub Pages workflow.
 - Manifest.csv now includes filesize_bytes, exif_camera, exif_datetime.
 - Error log drawer added to UI; shows per-file failures after run.
 - Service worker cache bumped and now includes exif worker.
+
+## [0.1.3] - 2025-09-27
+- UI polish: drag–drop area, toasts, clearer states.
+- HEIC detection: friendly prompt + skip un-decodable files.
+- Export auto-switch: “Auto (PNG if alpha)”.
+- Stability: safer worker fallback, bounds checks, better error handling.

--- a/web/index.html
+++ b/web/index.html
@@ -25,9 +25,19 @@
     input[type="file"] { display:none; }
     .pill { border:1px solid var(--ce-border); padding:8px 12px; border-radius:999px; cursor:pointer; }
     .pill.active { background: var(--ce-black); color: var(--ce-white); border-color: var(--ce-black); }
+
+    /* Drag–drop */
+    .drop { margin-top: 12px; padding: 20px; border: 2px dashed var(--ce-border); border-radius: 16px; text-align: center; background: var(--ce-surface); }
+    .drop.highlight { border-color: var(--ce-purple); box-shadow: 0 0 0 4px rgba(139,92,246,0.08); }
+
+    /* Toasts */
+    #toasts { position: fixed; z-index: 9999; left: 50%; transform: translateX(-50%); top: 12px; display: flex; flex-direction: column; gap: 8px; }
+    .toast { background: var(--ce-surface); border:1px solid var(--ce-border); box-shadow: 0 6px 24px rgba(0,0,0,0.08); padding: 10px 12px; border-radius: 12px; font-size: .95rem; }
   </style>
 </head>
 <body>
+  <div id="toasts" aria-live="polite"></div>
+
   <div class="wrap">
     <header>
       <img src="./assets/logo.png" alt="Logo" onerror="this.style.display='none'"/>
@@ -41,6 +51,10 @@
           Pick images
         </label>
         <div id="count" class="muted">No files selected</div>
+      </div>
+
+      <div class="drop" id="drop">
+        Drag & drop images here (or tap Pick images)
       </div>
 
       <div style="height:12px"></div>
@@ -58,7 +72,8 @@
           <label><input id="square" type="checkbox"> Make square (center-crop)</label>
           <label>Format
             <select id="format">
-              <option value="jpg" selected>JPG</option>
+              <option value="auto" selected>Auto (PNG if alpha)</option>
+              <option value="jpg">JPG</option>
               <option value="png">PNG</option>
             </select>
           </label>

--- a/web/main.js
+++ b/web/main.js
@@ -11,10 +11,15 @@ const qwrap = document.getElementById("qwrap");
 const errorList = document.getElementById("errorList");
 const errorBox = document.getElementById("errorBox");
 const errorCount = document.getElementById("errorCount");
+const drop = document.getElementById("drop");
+const toasts = document.getElementById("toasts");
 
 let files = [];
 let controller = null;
 
+const MAX_FILES = 60;
+
+// Presets
 const presetEls = Array.from(document.querySelectorAll("#presets .pill"));
 presetEls.forEach(el=>{
   el.addEventListener("click", ()=>{
@@ -31,20 +36,73 @@ document.getElementById("customSize").addEventListener("input", ()=>{
 });
 
 document.getElementById("format").addEventListener("change", (e)=>{
+  // hide quality when PNG or Auto (PNG chosen)
   qwrap.style.display = e.target.value === "jpg" ? "flex" : "none";
 });
 
 fileInput.addEventListener("change", ()=>{
-  files = Array.from(fileInput.files || []);
-  countEl.textContent = files.length ? `${files.length} files selected` : "No files selected";
-  goBtn.disabled = files.length === 0;
+  setFiles(Array.from(fileInput.files || []));
 });
 
 document.getElementById("wmToggle").addEventListener("change", update);
 
+// Drag–drop handlers
+;["dragenter","dragover"].forEach(ev=>{
+  drop.addEventListener(ev, (e)=>{ e.preventDefault(); e.stopPropagation(); drop.classList.add("highlight"); });
+  document.addEventListener(ev, (e)=>{ e.preventDefault(); });
+});
+;["dragleave","drop"].forEach(ev=>{
+  drop.addEventListener(ev, (e)=>{ e.preventDefault(); e.stopPropagation(); drop.classList.remove("highlight"); });
+});
+drop.addEventListener("drop", (e)=>{
+  const fl = Array.from(e.dataTransfer?.files || []).filter(f=>f && f.type?.startsWith("image/") || /\.(jpe?g|png|webp|heic)$/i.test(f.name));
+  if (fl.length === 0) { toast("No images detected in drop."); return; }
+  setFiles((files||[]).concat(fl));
+});
+
+function setFiles(incoming) {
+  const normalized = normalizeFiles(incoming);
+  const { usable, heic, tooMany } = partitionFiles(normalized);
+  files = usable.slice(0, MAX_FILES);
+  countEl.textContent = files.length ? `${files.length} files selected` : "No files selected";
+  goBtn.disabled = files.length === 0;
+
+  if (heic.length) {
+    toast(`Some HEIC images were skipped (not supported by many browsers). Convert first: ${heic.slice(0,3).map(f=>f.name).join(", ")}${heic.length>3?"…":""}`);
+  }
+  if (tooMany) {
+    toast(`Capped to ${MAX_FILES} files for stability. You can run another batch after this.`);
+  }
+}
+
+function normalizeFiles(arr) {
+  // De-dupe by name+size to avoid accidental duplicates
+  const seen = new Set();
+  const out = [];
+  for (const f of arr) {
+    if (!f) continue;
+    const key = `${f.name}__${f.size}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(f);
+  }
+  return out;
+}
+
+function partitionFiles(arr) {
+  const usable = [];
+  const heic = [];
+  for (const f of arr) {
+    const isHeic = /image\/heic/i.test(f.type) || /\.heic$/i.test(f.name);
+    if (isHeic) heic.push(f);
+    else usable.push(f);
+  }
+  return { usable, heic, tooMany: arr.length > MAX_FILES };
+}
+
 function getSize() {
   const custom = parseInt(document.getElementById("customSize").value, 10);
-  if (!isNaN(custom) && custom > 0) return custom;
+  if (!isNaN(custom) && custom > 0) return Math.min(4096, Math.max(64, custom));
   const active = document.querySelector("#presets .pill.active");
   return parseInt(active.dataset.size, 10);
 }
@@ -53,7 +111,7 @@ function getOpts() {
   return {
     size: getSize(),
     square: document.getElementById("square").checked,
-    format: document.getElementById("format").value,
+    format: document.getElementById("format").value, // 'auto'|'jpg'|'png'
     quality: parseInt(document.getElementById("quality").value, 10),
     watermark: document.getElementById("wmToggle").checked ? (document.getElementById("wmText").value || "©") : null
   };
@@ -64,6 +122,8 @@ function update() {
 }
 
 goBtn.addEventListener("click", async ()=>{
+  if (!files.length) { toast("Pick images first."); return; }
+
   controller = new AbortController();
   goBtn.disabled = true;
   stopBtn.disabled = false;
@@ -88,13 +148,18 @@ goBtn.addEventListener("click", async ()=>{
       errorCount.textContent = String(failures.length);
       errorList.innerHTML = failures.map(f => `<li><strong>${escapeHtml(f.name)}</strong> — ${escapeHtml(f.error)}</li>`).join("");
       errorBox.open = true;
+      toast(`Completed with ${failures.length} error${failures.length>1?"s":""}. See details below.`);
+    } else {
+      toast("All images processed successfully.");
     }
   } catch (e) {
     if (e.name === "AbortError") {
       statusEl.textContent = "Stopped.";
+      toast("Batch stopped.");
     } else {
       console.error(e);
       statusEl.textContent = "Error. See console for details.";
+      toast("Unexpected error. See console.");
     }
   } finally {
     stopBtn.disabled = true;
@@ -108,4 +173,16 @@ stopBtn.addEventListener("click", ()=>{
 
 function escapeHtml(s) {
   return String(s).replace(/[&<>"']/g, m => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;','\'':'&#39;'}[m]));
+}
+
+function toast(msg, ms=3500) {
+  const el = document.createElement("div");
+  el.className = "toast";
+  el.textContent = msg;
+  toasts.appendChild(el);
+  setTimeout(()=> {
+    el.style.opacity = "0";
+    el.style.transform = "translateY(-6px)";
+  }, ms);
+  setTimeout(()=> el.remove(), ms+400);
 }

--- a/web/sw.js
+++ b/web/sw.js
@@ -1,4 +1,4 @@
-const CACHE = "ce-thumbgen-v0.1.1";
+const CACHE = "ce-thumbgen-v0.1.3";
 const ASSETS = [
   "./",
   "./index.html",

--- a/web/worker/dispatcher.js
+++ b/web/worker/dispatcher.js
@@ -4,6 +4,12 @@ const MAX_WORKERS = (navigator.hardwareConcurrency && navigator.hardwareConcurre
 const WORKERS = Math.max(2, Math.min(MAX_WORKERS, navigator.hardwareConcurrency || 2));
 
 export async function runBatch(files, opts, {signal, onProgress}) {
+  // Fallback if Workers not available (very old/limited browsers)
+  const canWorkers = typeof Worker !== "undefined";
+  if (!canWorkers) {
+    return runSequentialOnMain(files, opts, {signal, onProgress});
+  }
+
   const queue = files.slice();
   let done = 0;
 
@@ -13,16 +19,20 @@ export async function runBatch(files, opts, {signal, onProgress}) {
   const tasks = workers.map(async (w) => {
     while (queue.length && !signal.aborted) {
       const file = queue.shift();
-      const arrayBuf = await file.arrayBuffer();
-      const res = await callWorker(w, { arrayBuf, name: file.name, opts, sizeBytes: file.size });
-      results.push(res);
+      try {
+        const arrayBuf = await file.arrayBuffer();
+        const res = await callWorker(w, { arrayBuf, name: file.name, opts, sizeBytes: file.size });
+        results.push(res);
+      } catch (err) {
+        results.push({ ok:false, name:file.name, error:String(err) });
+      }
       done += 1;
       onProgress?.(done, files.length);
     }
   });
 
   signal.addEventListener("abort", ()=>workers.forEach(w=>w.terminate()), { once:true });
-  await Promise.all(tasks);
+  await Promise.allSettled(tasks);
   workers.forEach(w=>w.terminate());
 
   const { zipBlob, manifestCsv } = await makeZip(results);
@@ -32,10 +42,37 @@ export async function runBatch(files, opts, {signal, onProgress}) {
 
 function callWorker(worker, msg) {
   return new Promise((resolve, reject) => {
-    const onMessage = (e) => { worker.removeEventListener("message", onMessage); resolve(e.data); };
-    const onError = (e) => { worker.removeEventListener("error", onError); reject(e.error || e); };
+    const onMessage = (e) => { cleanup(); resolve(e.data); };
+    const onError = (e) => { cleanup(); reject(e.error || e.message || e); };
+    const cleanup = () => {
+      worker.removeEventListener("message", onMessage);
+      worker.removeEventListener("error", onError);
+    };
+    try { worker.postMessage(msg, [msg.arrayBuf]); }
+    catch (err) { cleanup(); reject(err); return; }
     worker.addEventListener("message", onMessage);
     worker.addEventListener("error", onError);
-    worker.postMessage(msg, [msg.arrayBuf]);
   });
+}
+
+// Minimal sequential fallback (main thread). Slower, but keeps the app usable.
+async function runSequentialOnMain(files, opts, {signal, onProgress}) {
+  const results = [];
+  let done = 0;
+  for (const f of files) {
+    if (signal.aborted) break;
+    try {
+      const arrayBuf = await f.arrayBuffer();
+      const mod = await import("./img-worker.js"); // uses same code paths
+      const res = await mod.processOne(arrayBuf, f.name, opts, f.size);
+      results.push(res);
+    } catch (err) {
+      results.push({ ok:false, name:f.name, error:String(err) });
+    }
+    done += 1;
+    onProgress?.(done, files.length);
+  }
+  const { zipBlob, manifestCsv } = await makeZip(results);
+  const failures = results.filter(r => !r.ok).map(r => ({ name: r.name, error: r.error || "Unknown error" }));
+  return { zipBlob, manifestCsv, failures };
 }

--- a/web/worker/img-worker.js
+++ b/web/worker/img-worker.js
@@ -1,48 +1,60 @@
 import { parseExifMeta } from "./exif.js";
 
+// Worker entry
 self.onmessage = async (e) => {
   const { arrayBuf, name, opts, sizeBytes } = e.data;
-  try {
-    const meta = parseExifMeta(arrayBuf);
-    const blob = new Blob([arrayBuf]);
-    const bitmap = await createImageBitmap(blob);
-
-    const oriented = await orientBitmap(bitmap, meta.orientation || 1);
-    const { canvas, w, h } = await resizeBitmap(oriented, opts);
-
-    const outType = opts.format === "png" ? "image/png" : "image/jpeg";
-    const quality = opts.format === "png" ? undefined : Math.max(0.1, Math.min(1, (opts.quality || 85) / 100));
-
-    try { tinySharpen(canvas, 0.15); } catch {}
-
-    const outBlob = await (canvas.convertToBlob
-      ? canvas.convertToBlob({ type: outType, quality })
-      : new Promise(r => canvas.toBlob(r, outType, quality)));
-
-    const thumbName = makeName(name, w, h, opts.square ? "crop" : "fit", outType);
-    const buf = await outBlob.arrayBuffer();
-
-    self.postMessage({
-      ok: true,
-      name,
-      thumbName,
-      width: w,
-      height: h,
-      sizeBytes,
-      exif_camera: compactCamera(meta.make, meta.model),
-      exif_datetime: meta.dateTimeOriginal || null,
-      data: new Uint8Array(buf)
-    }, [buf]);
-  } catch (err) {
-    self.postMessage({ ok:false, name, error:String(err) });
+  const out = await processOne(arrayBuf, name, opts, sizeBytes).catch(err => ({ ok:false, name, error:String(err) }));
+  // If ok, transfer the typed array buffer to avoid copies
+  if (out && out.ok && out.data && out.data.buffer) {
+    self.postMessage(out, [out.data.buffer]);
+  } else {
+    self.postMessage(out);
   }
 };
+
+// Exported for main-thread fallback
+export async function processOne(arrayBuf, name, opts, sizeBytes) {
+  const meta = parseExifMeta(arrayBuf);
+  const blob = new Blob([arrayBuf]);
+  const bitmap = await createImageBitmap(blob);
+
+  const oriented = await orientBitmap(bitmap, meta.orientation || 1);
+  const { canvas, w, h } = await resizeBitmap(oriented, opts);
+
+  const detectedAlpha = opts.square ? false : await hasAlphaSampled(canvas);
+  const outMime =
+    opts.format === "png" ? "image/png" :
+    opts.format === "jpg" ? "image/jpeg" :
+    detectedAlpha ? "image/png" : "image/jpeg";
+
+  const quality = outMime === "image/jpeg" ? Math.max(0.1, Math.min(1, (opts.quality || 85) / 100)) : undefined;
+
+  try { tinySharpen(canvas, 0.15); } catch {}
+
+  const outBlob = await (canvas.convertToBlob
+    ? canvas.convertToBlob({ type: outMime, quality })
+    : new Promise(r => canvas.toBlob(r, outMime, quality)));
+
+  const thumbName = makeName(name, w, h, opts.square ? "crop" : "fit", outMime);
+  const buf = await outBlob.arrayBuffer();
+
+  return {
+    ok: true,
+    name,
+    thumbName,
+    width: w,
+    height: h,
+    sizeBytes,
+    exif_camera: compactCamera(meta.make, meta.model),
+    exif_datetime: meta.dateTimeOriginal || null,
+    data: new Uint8Array(buf)
+  };
+}
 
 function compactCamera(make, model) {
   if (!make && !model) return null;
   if (make && model) {
-    // avoid repeating brand twice if model already starts with it
-    return model.toLowerCase().startsWith((make || "").toLowerCase()) ? model : `${make} ${model}`.trim();
+    return model.toLowerCase().startsWith((make||"").toLowerCase()) ? model : `${make} ${model}`.trim();
   }
   return (make || model || null);
 }
@@ -60,7 +72,7 @@ async function orientBitmap(bitmap, orientation) {
   const cw = swap ? h : w;
   const ch = swap ? w : h;
 
-  const off = new OffscreenCanvas(cw, ch);
+  const off = new OffscreenCanvas ? new OffscreenCanvas(cw, ch) : (()=>{ const c=document.createElement("canvas"); c.width=cw; c.height=ch; return c; })();
   const ctx = off.getContext("2d");
   ctx.save();
   switch (orientation) {
@@ -78,12 +90,12 @@ async function orientBitmap(bitmap, orientation) {
 }
 
 async function resizeBitmap(bitmap, opts) {
-  const long = opts.size || 512;
+  const long = Math.max(64, Math.min(4096, opts.size || 512));
   if (opts.square) {
     const s = Math.min(bitmap.width, bitmap.height);
     const sx = (bitmap.width - s)/2;
     const sy = (bitmap.height - s)/2;
-    const off = new OffscreenCanvas(long, long);
+    const off = new OffscreenCanvas ? new OffscreenCanvas(long, long) : (()=>{ const c=document.createElement("canvas"); c.width=long; c.height=long; return c; })();
     const ctx = off.getContext("2d");
     ctx.drawImage(bitmap, sx, sy, s, s, 0, 0, long, long);
     if (opts.watermark) placeWatermark(ctx, long, long, opts.watermark);
@@ -92,7 +104,7 @@ async function resizeBitmap(bitmap, opts) {
     const scale = bitmap.width >= bitmap.height ? long / bitmap.width : long / bitmap.height;
     const targetW = Math.max(1, Math.round(bitmap.width * scale));
     const targetH = Math.max(1, Math.round(bitmap.height * scale));
-    const off = new OffscreenCanvas(targetW, targetH);
+    const off = new OffscreenCanvas ? new OffscreenCanvas(targetW, targetH) : (()=>{ const c=document.createElement("canvas"); c.width=targetW; c.height=targetH; return c; })();
     const ctx = off.getContext("2d");
     ctx.drawImage(bitmap, 0, 0, targetW, targetH);
     if (opts.watermark) placeWatermark(ctx, targetW, targetH, opts.watermark);
@@ -111,10 +123,30 @@ function placeWatermark(ctx, w, h, text) {
   ctx.restore();
 }
 
+// Sample alpha existence quickly to decide PNG vs JPG in 'auto'
+async function hasAlphaSampled(canvas) {
+  const ctx = canvas.getContext("2d", { willReadFrequently: true });
+  const { width:w, height:h } = canvas;
+  // Sample a grid up to 64x64 points to avoid heavy reads
+  const stepsX = Math.min(64, w);
+  const stepsY = Math.min(64, h);
+  const stepX = Math.max(1, Math.floor(w/stepsX));
+  const stepY = Math.max(1, Math.floor(h/stepsY));
+  for (let y=0; y<h; y+=stepY) {
+    const row = ctx.getImageData(0, y, w, 1).data;
+    for (let x=0; x<w; x+=stepX) {
+      // alpha channel at index 3
+      if (row[(x*4)+3] < 255) return true;
+    }
+  }
+  return false;
+}
+
 // Tiny sharpen
 function tinySharpen(canvas, amount = 0.15) {
   const ctx = canvas.getContext("2d");
   const { width:w, height:h } = canvas;
+  if (w < 3 || h < 3) return; // avoid tiny images artifacts
   const img = ctx.getImageData(0,0,w,h);
   const src = img.data;
   const out = new Uint8ClampedArray(src.length);
@@ -126,17 +158,18 @@ function tinySharpen(canvas, amount = 0.15) {
   const idx = (x,y) => ((y*w)+x)*4;
   for (let y=1; y<h-1; y++) {
     for (let x=1; x<w-1; x++) {
+      const p = idx(x,y);
+      out[p+3] = src[p+3];
       for (let c=0; c<3; c++) {
         let v=0, i=0;
         for (let ky=-1; ky<=1; ky++) {
           for (let kx=-1; kx<=1; kx++, i++) v += src[idx(x+kx,y+ky)+c] * k[i];
         }
-        out[idx(x,y)+c] = Math.max(0, Math.min(255, v));
+        out[p+c] = v < 0 ? 0 : v > 255 ? 255 : v;
       }
-      out[idx(x,y)+3] = src[idx(x,y)+3];
     }
   }
-  // Copy edges
+  // Copy borders
   out.set(src.slice(0, w*4));
   out.set(src.slice((h-1)*w*4), (h-1)*w*4);
   for (let y=1; y<h-1; y++) {


### PR DESCRIPTION
## Summary
- polish the web UI with drag-and-drop uploads, toast notifications, and clearer controls
- add HEIC filtering, file dedupe, and automatic format selection logic in the main app
- improve worker dispatching, sequential fallback, and service worker cache version for 0.1.3

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d71006e7808331a902862b1701bc74