### PR TITLE
Add folder export workflow and UI updates

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -24,3 +24,8 @@ Added local dev guide and GitHub Pages workflow.
 - HEIC detection: friendly prompt + skip un-decodable files.
 - Export auto-switch: “Auto (PNG if alpha)”.
 - Stability: safer worker fallback, bounds checks, better error handling.
+
+## [0.1.4] - 2025-09-27
+- Desktop polish: drag–drop of folders (Chrome/Edge).
+- File System Access: “Save to Folder” and “Open saved folder” UX.
+- Keeps ZIP download as fallback/default for all browsers.

--- a/web/index.html
+++ b/web/index.html
@@ -15,6 +15,8 @@
     .card { background: var(--ce-surface); border: 1px solid var(--ce-border); border-radius: 16px; padding: 16px; box-shadow: 0 2px 8px rgba(0,0,0,0.04); }
     .row { display:flex; gap: 12px; align-items: center; flex-wrap: wrap; }
     .btn { background: var(--ce-black); color: var(--ce-white); border: none; padding: 12px 16px; border-radius: 12px; cursor: pointer; }
+    .btn.alt { background: var(--ce-purple); }
+    .btn.ghost { background: transparent; color: var(--ce-black); border:1px solid var(--ce-border); }
     .btn:disabled { opacity: .6; cursor: not-allowed; }
     .muted { color: var(--ce-muted); font-size: .9rem; }
     .progress { height: 8px; background: var(--ce-border); border-radius: 999px; overflow: hidden; }
@@ -47,14 +49,14 @@
     <div class="card">
       <div class="row">
         <label class="btn">
-          <input id="fileInput" type="file" accept="image/*" multiple>
-          Pick images
+          <input id="fileInput" type="file" accept="image/*" multiple webkitdirectory>
+          Pick images / folder
         </label>
         <div id="count" class="muted">No files selected</div>
       </div>
 
       <div class="drop" id="drop">
-        Drag & drop images here (or tap Pick images)
+        Drag & drop images or a folder here (Chrome/Edge)
       </div>
 
       <div style="height:12px"></div>
@@ -90,6 +92,9 @@
       <div class="row">
         <button id="go" class="btn" disabled>Generate Thumbnails</button>
         <button id="stop" class="btn" style="background:var(--ce-red)" disabled>Stop</button>
+        <button id="saveZip" class="btn alt" disabled>Download ZIP</button>
+        <button id="saveFolder" class="btn ghost" disabled>Save to Folder</button>
+        <button id="openFolder" class="btn ghost" disabled>Open saved folder</button>
       </div>
 
       <div style="height:12px"></div>

--- a/web/sw.js
+++ b/web/sw.js
@@ -1,4 +1,4 @@
-const CACHE = "ce-thumbgen-v0.1.3";
+const CACHE = "ce-thumbgen-v0.1.4";
 const ASSETS = [
   "./",
   "./index.html",
@@ -17,15 +17,9 @@ const ASSETS = [
 self.addEventListener("install", (e) => {
   e.waitUntil(caches.open(CACHE).then(c => c.addAll(ASSETS)));
 });
-
 self.addEventListener("activate", (e) => {
-  e.waitUntil(
-    caches.keys().then(keys => Promise.all(keys.filter(k=>k!==CACHE).map(k=>caches.delete(k))))
-  );
+  e.waitUntil(caches.keys().then(keys => Promise.all(keys.filter(k=>k!==CACHE).map(k=>caches.delete(k)))));
 });
-
 self.addEventListener("fetch", (e) => {
-  e.respondWith(
-    caches.match(e.request).then(r => r || fetch(e.request))
-  );
+  e.respondWith(caches.match(e.request).then(r => r || fetch(e.request)));
 });

--- a/web/worker/zipper-worker.js
+++ b/web/worker/zipper-worker.js
@@ -24,16 +24,18 @@ export async function makeZip(results) {
   return { zipBlob, manifestCsv };
 }
 
-function quote(s) {
-  return `"${String(s).replace(/"/g, '""')}"`;
-}
-function quoteOrEmpty(s) {
-  return s ? quote(s) : "";
+// Provide a list of files for folder save UX
+export async function buildFileList(results, manifestCsv) {
+  const ok = results.filter(r => r.ok);
+  const list = [{ name: "manifest.csv", data: new TextEncoder().encode(manifestCsv) }];
+  for (const r of ok) list.push({ name: `thumbs/${r.thumbName}`, data: r.data });
+  return list;
 }
 
+function quote(s) { return `"${String(s).replace(/"/g, '""')}"`; }
+function quoteOrEmpty(s) { return s ? quote(s) : ""; }
+
 async function createZip(entries) {
-  // Store method ZIP for portability. Modern browsers handle CompressionStream,
-  // but we keep simple and small here.
   const { blob, writer } = makeBlobWriter();
   for (const e of entries) await writeZipEntry(writer, e.name, e.data);
   await finishZip(writer);

--- a/web/zipper.js
+++ b/web/zipper.js
@@ -1,3 +1,5 @@
+let lastDirHandle = null;
+
 export async function saveZip(blob, filename) {
   // Prefer native File System Access if available
   if (window.showSaveFilePicker) {
@@ -12,4 +14,62 @@ export async function saveZip(blob, filename) {
     a.click();
     setTimeout(()=>URL.revokeObjectURL(a.href), 5000);
   }
+}
+
+export async function saveFilesToFolder(files, subdir = "thumbs") {
+  if (!("showDirectoryPicker" in window)) {
+    alert("Your browser does not support saving to a folder. Use Download ZIP instead.");
+    return false;
+  }
+  try {
+    const dir = await showDirectoryPicker({ mode: "readwrite" });
+    lastDirHandle = dir;
+
+    // Create subdir if needed
+    const thumbsDir = await ensureDir(dir, subdir);
+
+    // Write manifest at root
+    for (const f of files) {
+      const pathParts = f.name.split("/");
+      if (pathParts.length === 1) {
+        await writeFile(dir, f.name, f.data);
+      } else {
+        // e.g. thumbs/foo.jpg
+        const targetDir = await ensureDir(dir, pathParts[0]);
+        await writeFile(targetDir, pathParts.slice(1).join("/"), f.data);
+      }
+    }
+    return true;
+  } catch (e) {
+    console.error(e);
+    alert("Could not save to folder.");
+    return false;
+  }
+}
+
+export async function reOpenFolder() {
+  if (!("showDirectoryPicker" in window)) return;
+  try {
+    // We cannot auto-open the OS explorer, but we can prompt with the picker.
+    const dir = await showDirectoryPicker({ startIn: lastDirHandle || "documents" });
+    lastDirHandle = dir;
+  } catch {
+    // user cancelled
+  }
+}
+
+async function ensureDir(root, name) {
+  return await root.getDirectoryHandle(name, { create: true });
+}
+
+async function writeFile(dirHandle, path, data) {
+  const parts = path.split("/");
+  let current = dirHandle;
+  for (let i=0; i<parts.length-1; i++) {
+    current = await current.getDirectoryHandle(parts[i], { create: true });
+  }
+  const fileHandle = await current.getFileHandle(parts[parts.length-1], { create: true });
+  const writable = await fileHandle.createWritable();
+  await writable.write(data);
+  await writable.close();
 }


### PR DESCRIPTION
## Summary
- enable folder drag-and-drop selection and new save controls in the web UI
- add File System Access saving helpers and worker plumbing for manifest-aware exports
- refresh service worker cache list and changelog for version 0.1.4

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d712e801b08331ba871d299872e99b