### PR TITLE
Split file and folder pickers in web UI

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -49,8 +49,12 @@
     <div class="card">
       <div class="row">
         <label class="btn">
-          <input id="fileInput" type="file" accept="image/*" multiple webkitdirectory>
-          Pick images / folder
+          <input id="fileInput" type="file" accept="image/*" multiple>
+          Pick images
+        </label>
+        <label class="btn">
+          <input id="folderInput" type="file" webkitdirectory>
+          Pick folder
         </label>
         <div id="count" class="muted">No files selected</div>
       </div>

--- a/web/main.js
+++ b/web/main.js
@@ -48,6 +48,11 @@ fileInput.addEventListener("change", ()=>{
   setFiles(Array.from(fileInput.files || []));
 });
 
+const folderInput = document.getElementById("folderInput");
+folderInput.addEventListener("change", ()=>{
+  setFiles(Array.from(folderInput.files || []));
+});
+
 document.getElementById("wmToggle").addEventListener("change", update);
 
 // Drag–drop folder & files


### PR DESCRIPTION
## Summary
- replace the combined file/folder picker with separate buttons for files and folders
- connect the new folder input to the existing file selection handler

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d7185180908331a36de33437475c61