### PR TITLE
Update zipper worker and refresh web assets

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
   <title>CerclEnclume — Thumbnail Generator</title>
   <link rel="manifest" href="./manifest.webmanifest">
+  <link rel="icon" href="./assets/logo.png">
   <link rel="stylesheet" href="./assets/brand-tokens.css">
   <style>
     html, body { margin:0; padding:0; background:var(--ce-bg); color:var(--ce-ink); font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; }

--- a/web/sw.js
+++ b/web/sw.js
@@ -1,4 +1,4 @@
-const CACHE = "ce-thumbgen-v0.1.4";
+const CACHE = "ce-thumbgen-v0.1.5";
 const ASSETS = [
   "./",
   "./index.html",

--- a/web/worker/zipper-worker.js
+++ b/web/worker/zipper-worker.js
@@ -35,92 +35,92 @@ export async function buildFileList(results, manifestCsv) {
 function quote(s) { return `"${String(s).replace(/"/g, '""')}"`; }
 function quoteOrEmpty(s) { return s ? quote(s) : ""; }
 
+// ---- ZIP (store method) ----
+// NOTE: Simplified shape: writer is {chunks:[], central:[]}
 async function createZip(entries) {
-  const { blob, writer } = makeBlobWriter();
+  const writer = makeWriter();
   for (const e of entries) await writeZipEntry(writer, e.name, e.data);
   await finishZip(writer);
-  return blob();
+  return new Blob(writer.chunks, { type: "application/zip" });
 }
 
-function makeBlobWriter() {
-  const chunks = [];
-  return {
-    writer: { chunks, central: [] },
-    blob: () => new Blob(chunks, { type: "application/zip" })
-  };
+function makeWriter() {
+  return { chunks: [], central: [] };
 }
 
 async function writeZipEntry(w, name, data) {
-  const encoder = new TextEncoder();
-  const nameBytes = encoder.encode(name);
+  if (!data || !("byteLength" in data)) data = new Uint8Array(0);
+  const enc = new TextEncoder();
+  const nameBytes = enc.encode(name);
   const crc = crc32(data);
+
   const header = new DataView(new ArrayBuffer(30));
   header.setUint32(0, 0x04034b50, true);
-  header.setUint16(4, 20, true);
-  header.setUint16(6, 0, true);
-  header.setUint16(8, 0, true);
-  header.setUint16(10, 0, true);
-  header.setUint16(12, 0, true);
+  header.setUint16(4, 20, true); // version needed
+  header.setUint16(6, 0, true);  // flags
+  header.setUint16(8, 0, true);  // method: store
+  header.setUint16(10, 0, true); // time
+  header.setUint16(12, 0, true); // date
   header.setUint32(14, crc, true);
   header.setUint32(18, data.byteLength, true);
   header.setUint32(22, data.byteLength, true);
   header.setUint16(26, nameBytes.byteLength, true);
-  header.setUint16(28, 0, true);
-  w.writer.chunks.push(header, nameBytes, data);
+  header.setUint16(28, 0, true); // extra len
 
-  w.writer.central.push({ nameBytes, crc, size: data.byteLength, offset: totalSize(w.writer.chunks) - (30 + nameBytes.byteLength + data.byteLength) });
+  w.chunks.push(header, nameBytes, data);
+
+  const offset = totalSize(w.chunks) - (30 + nameBytes.byteLength + data.byteLength);
+  w.central.push({ nameBytes, crc, size: data.byteLength, offset });
 }
 
 async function finishZip(w) {
-  const centralStart = totalSize(w.chunks);
+  const start = totalSize(w.chunks);
   for (const f of w.central) {
     const hdr = new DataView(new ArrayBuffer(46));
     hdr.setUint32(0, 0x02014b50, true);
-    hdr.setUint16(4, 20, true);
-    hdr.setUint16(6, 20, true);
-    hdr.setUint16(8, 0, true);
-    hdr.setUint16(10, 0, true);
-    hdr.setUint16(12, 0, true);
-    hdr.setUint16(14, 0, true);
+    hdr.setUint16(4, 20, true); // version made by
+    hdr.setUint16(6, 20, true); // version needed
+    hdr.setUint16(8, 0, true);  // flags
+    hdr.setUint16(10, 0, true); // method
+    hdr.setUint16(12, 0, true); // time
+    hdr.setUint16(14, 0, true); // date
     hdr.setUint32(16, f.crc, true);
     hdr.setUint32(20, f.size, true);
     hdr.setUint32(24, f.size, true);
     hdr.setUint16(28, f.nameBytes.byteLength, true);
-    hdr.setUint16(30, 0, true);
-    hdr.setUint16(32, 0, true);
-    hdr.setUint16(34, 0, true);
-    hdr.setUint16(36, 0, true);
-    hdr.setUint32(38, 0, true);
+    hdr.setUint16(30, 0, true); // extra
+    hdr.setUint16(32, 0, true); // comment
+    hdr.setUint16(34, 0, true); // disk#
+    hdr.setUint16(36, 0, true); // int attrs
+    hdr.setUint32(38, 0, true); // ext attrs
     hdr.setUint32(42, f.offset, true);
     w.chunks.push(hdr, f.nameBytes);
   }
-  const centralEnd = totalSize(w.chunks);
-  const record = new DataView(new ArrayBuffer(22));
-  record.setUint32(0, 0x06054b50, true);
-  record.setUint16(4, 0, true);
-  record.setUint16(6, 0, true);
-  record.setUint16(8, w.central.length, true);
-  record.setUint16(10, w.central.length, true);
-  record.setUint32(12, centralEnd - centralStart, true);
-  record.setUint32(16, centralStart, true);
-  record.setUint16(20, 0, true);
-  w.chunks.push(record);
+  const end = totalSize(w.chunks);
+  const rec = new DataView(new ArrayBuffer(22));
+  rec.setUint32(0, 0x06054b50, true);
+  rec.setUint16(4, 0, true);
+  rec.setUint16(6, 0, true);
+  rec.setUint16(8, w.central.length, true);
+  rec.setUint16(10, w.central.length, true);
+  rec.setUint32(12, end - start, true);
+  rec.setUint32(16, start, true);
+  rec.setUint16(20, 0, true);
+  w.chunks.push(rec);
 }
 
 function totalSize(chunks) {
   let n = 0;
-  for (const c of chunks) n += c.byteLength || c.length || 0;
+  for (const c of chunks) n += (c.byteLength ?? c.length ?? 0);
   return n;
 }
 
 function crc32(buf) {
+  const b = buf instanceof Uint8Array ? buf : new Uint8Array(buf);
   let c = ~0 >>> 0;
-  for (let i=0; i<buf.length; i++) {
-    c = (c ^ buf[i]) >>> 0;
-    for (let k=0; k<8; k++) {
-      const m = -(c & 1);
-      c = (c >>> 1) ^ (0xEDB88320 & m);
-    }
+  for (let i=0; i<b.length; i++) {
+    c ^= b[i];
+    for (let k=0; k<8; k++) c = (c >>> 1) ^ (0xEDB88320 & -(c & 1));
   }
   return (~c) >>> 0;
 }


### PR DESCRIPTION
## Summary
- rewrite the zipper worker to use a simplified writer structure and handle missing data safely
- add a favicon reference so the browser stops requesting a missing icon while keeping the logo fallback
- bump the service worker cache version to force clients to fetch the updated bundle

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d719ca008c8331bf1dce1affbce881